### PR TITLE
fix: skip protocol messages to avoid polluting message database

### DIFF
--- a/whatsapp/handlers.go
+++ b/whatsapp/handlers.go
@@ -237,6 +237,12 @@ func (c *Client) parseHistoryMessage(chatJID types.JID, msg *waWeb.WebMessageInf
 			pushName = pushNameMap[info.Sender.String()]
 		}
 
+		// skip protocol messages in history sync
+		if msg.GetMessage().GetProtocolMessage() != nil {
+			c.log.Debugf("Skipping protocol message in history sync")
+			return nil
+		}
+
 		text := extractText(msg.GetMessage())
 		if text == "" {
 			message := msg.GetMessage()
@@ -356,6 +362,12 @@ func (c *Client) handleMessage(evt *events.Message) {
 	mediaType := getMediaTypeFromMessage(evt.Message)
 	if mediaType != "" && mediaType != "vcard" && mediaType != "contact_array" {
 		mediaMetadata = c.extractMediaMetadata(evt.Message, info.ID, false)
+	}
+
+	// skip protocol messages (edits, deletes, encryption updates, etc.)
+	if evt.Message.GetProtocolMessage() != nil {
+		c.log.Debugf("Skipping protocol message (system message type)")
+		return
 	}
 
 	text := extractText(evt.Message)


### PR DESCRIPTION
## Summary

Protocol messages (encryption updates, message edits/deletes, key distribution) are internal WhatsApp housekeeping that provides no useful content for MCP consumers. Currently they get stored as `[Protocol]` entries that clutter the database.

This PR filters them out in both:
- **Live message handling** (`handleMessage`)
- **History sync** (`parseHistoryMessage`)

## Changes

- Add early return in `handleMessage` when `GetProtocolMessage() != nil`
- Add early return in `parseHistoryMessage` when `GetProtocolMessage() != nil`

Only 6 lines of code added.

## Test plan

- [ ] Verify protocol messages are no longer stored in the database
- [ ] Verify regular messages (text, image, etc.) still work normally
- [ ] Verify history sync still processes all non-protocol messages