### PR TITLE
feat: add reply-to support in send_message tool

### DIFF
--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -428,8 +428,11 @@ func (m *MCPServer) handleSendMessage(ctx context.Context, request mcp.CallToolR
 		return mcp.NewToolResultError("WhatsApp is not connected"), nil
 	}
 
+	// get optional reply_to parameter
+	replyTo := request.GetString("reply_to", "")
+
 	// send message
-	err = m.wa.SendTextMessage(ctx, chatJID, text)
+	err = m.wa.SendTextMessage(ctx, chatJID, text, replyTo)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to send message: %v", err)), nil
 	}

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -76,7 +76,7 @@ func (m *MCPServer) registerTools() {
 	// 5. send message
 	m.server.AddTool(
 		mcp.NewTool("send_message",
-			mcp.WithDescription("Send a text message to a WhatsApp chat (DM or group)."),
+			mcp.WithDescription("Send a text message to a WhatsApp chat (DM or group). Supports replying to a specific message."),
 			mcp.WithString("chat_jid",
 				mcp.Required(),
 				mcp.Description("recipient chat JID from find_chat or list_chats"),
@@ -84,6 +84,9 @@ func (m *MCPServer) registerTools() {
 			mcp.WithString("text",
 				mcp.Required(),
 				mcp.Description("message text to send"),
+			),
+			mcp.WithString("reply_to",
+				mcp.Description("message ID to reply to (the reply will appear linked/quoted in the chat)"),
 			),
 		),
 		m.handleSendMessage,


### PR DESCRIPTION
## Summary

Add an optional `reply_to` parameter to the `send_message` tool that allows sending messages as quoted replies linked to a specific message ID.

- Uses `ExtendedTextMessage` with `ContextInfo` from whatsmeow
- Looks up the quoted message from the local database to populate the reply context
- Fully backwards-compatible: existing calls without `reply_to` work exactly as before

Closes #18

## Test plan

- [ ] Send a message without `reply_to` — should work as before
- [ ] Send a message with `reply_to` set to a valid message ID — should appear as a quoted reply in WhatsApp
- [ ] Send a message with an invalid `reply_to` ID — should return a clear error