### PR TITLE
feat: retry receipt handling with message proto storage

### DIFF
--- a/storage/migrations/004_add_message_proto.sql
+++ b/storage/migrations/004_add_message_proto.sql
@@ -1,0 +1,5 @@
+-- Add message_proto column to store serialized protobuf for retry receipt handling.
+-- When a recipient can't decrypt a message, WhatsApp sends a retry receipt
+-- requesting re-encryption. This column stores the original protobuf so the
+-- server can fulfill retry requests even after restart.
+ALTER TABLE messages ADD COLUMN message_proto BLOB;

--- a/whatsapp/client.go
+++ b/whatsapp/client.go
@@ -142,6 +142,28 @@ func NewClient(store *storage.MessageStore, mediaStore *storage.MediaStore, webh
 		cancel:           cancel,
 	}
 
+	// Configure retry receipt handler: when a recipient can't decrypt a message,
+	// WhatsApp sends a retry receipt. This callback loads the original protobuf
+	// from the database so the message can be re-encrypted and resent.
+	waClient.GetMessageForRetry = func(requester, to types.JID, id types.MessageID) *waE2E.Message {
+		protoBytes, err := store.GetMessageProto(string(id))
+		if err != nil {
+			logger.Warnf("Error loading message proto for retry %s: %v", id, err)
+			return nil
+		}
+		if protoBytes == nil {
+			logger.Debugf("No stored proto for retry %s", id)
+			return nil
+		}
+		var msg waE2E.Message
+		if err := proto.Unmarshal(protoBytes, &msg); err != nil {
+			logger.Warnf("Error unmarshalling message proto for retry %s: %v", id, err)
+			return nil
+		}
+		logger.Infof("Loaded message proto for retry %s", id)
+		return &msg
+	}
+
 	waClient.AddEventHandler(client.eventHandler)
 
 	return client, nil
@@ -207,6 +229,9 @@ func (c *Client) SendTextMessage(ctx context.Context, chatJID string, text strin
 		return err
 	}
 
+	// Add to recent messages cache for retry receipt handling
+	c.wa.DangerousInternals().AddRecentMessage(targetJID, resp.ID, &waE2E.Message{Conversation: proto.String(text)}, nil)
+
 	c.store.SaveMessage(storage.Message{
 		ID:          resp.ID,
 		ChatJID:     chatJID,
@@ -216,6 +241,13 @@ func (c *Client) SendTextMessage(ctx context.Context, chatJID string, text strin
 		IsFromMe:    true,
 		MessageType: "text",
 	})
+
+	// Persist protobuf for retry receipt handling across restarts
+	if protoBytes, err := proto.Marshal(&waE2E.Message{Conversation: proto.String(text)}); err == nil {
+		c.store.SaveMessageProto(resp.ID, protoBytes)
+	} else {
+		c.log.Warnf("Failed to marshal message proto for %s: %v", resp.ID, err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes duplicate outbound message issues by properly handling retry receipts from WhatsApp.

When a recipient can't decrypt a message, WhatsApp sends a retry receipt requesting the message be re-encrypted. Without this handling, the server has no way to fulfill these requests, which can result in message delivery failures.

### Changes

- **Proto storage**: Store serialized protobuf for each sent message in a new `message_proto` BLOB column
- **Retry callback**: Configure `GetMessageForRetry` on the whatsmeow client to load stored protos from the database
- **In-memory cache**: Add sent messages to whatsmeow's recent message cache via `DangerousInternals().AddRecentMessage()`
- **Upsert fix**: Replace `INSERT OR REPLACE` with `ON CONFLICT DO UPDATE` to prevent wiping columns not in the INSERT list

Related to #21

## Test plan

- [ ] Send a message and verify message_proto is stored in the database
- [ ] Verify retry receipts are handled (check logs for "Loaded message proto for retry")
- [ ] Verify ON CONFLICT upsert preserves all columns on duplicate message IDs
- [ ] Verify existing message flow still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)