### PR TITLE
feat: add download_media tool for retrying skipped/failed downloads

### DIFF
--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -528,6 +528,74 @@ func (m *MCPServer) handleLoadMoreMessages(ctx context.Context, request mcp.Call
 	return mcp.NewToolResultText(result.String()), nil
 }
 
+// handleDownloadMedia force-downloads skipped or failed media files.
+func (m *MCPServer) handleDownloadMedia(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	messageID := request.GetString("message_id", "")
+
+	limit := int(request.GetFloat("limit", 10.0))
+	if limit > 50 {
+		limit = 50
+	}
+
+	if messageID != "" {
+		// download specific message
+		meta, err := m.mediaStore.GetMediaMetadata(messageID)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get metadata: %v", err)), nil
+		}
+		if meta == nil {
+			return mcp.NewToolResultError(fmt.Sprintf("no media found for message %s", messageID)), nil
+		}
+		if meta.DownloadStatus == "downloaded" {
+			return mcp.NewToolResultText(fmt.Sprintf("Already downloaded: %s → %s", meta.FileName, meta.FilePath)), nil
+		}
+
+		filePath, err := m.wa.DownloadMediaFromMetadata(ctx, meta)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("download failed for %s: %v", meta.FileName, err)), nil
+		}
+		m.mediaStore.UpdateDownloadStatus(messageID, "downloaded", &filePath, nil)
+		return mcp.NewToolResultText(fmt.Sprintf("Downloaded: %s → %s", meta.FileName, filePath)), nil
+	}
+
+	// download all skipped/failed
+	skipped, err := m.mediaStore.GetSkippedMedia(limit)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list skipped media: %v", err)), nil
+	}
+
+	if len(skipped) == 0 {
+		return mcp.NewToolResultText("No skipped or failed media to download."), nil
+	}
+
+	var results []string
+	var dlErrors []string
+
+	for _, meta := range skipped {
+		filePath, err := m.wa.DownloadMediaFromMetadata(ctx, &meta)
+		if err != nil {
+			errMsg := fmt.Sprintf("FAILED %s (%s): %v", meta.FileName, meta.MessageID[:8], err)
+			dlErrors = append(dlErrors, errMsg)
+			m.mediaStore.UpdateDownloadStatus(meta.MessageID, "failed", nil, err)
+		} else {
+			m.mediaStore.UpdateDownloadStatus(meta.MessageID, "downloaded", &filePath, nil)
+			results = append(results, fmt.Sprintf("OK %s → %s", meta.FileName, filePath))
+		}
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Force download results (%d files):\n\n", len(skipped))
+	for _, r := range results {
+		fmt.Fprintf(&sb, "✅ %s\n", r)
+	}
+	for _, e := range dlErrors {
+		fmt.Fprintf(&sb, "❌ %s\n", e)
+	}
+	fmt.Fprintf(&sb, "\nTotal: %d OK, %d failed", len(results), len(dlErrors))
+
+	return mcp.NewToolResultText(sb.String()), nil
+}
+
 // handleGetMyInfo handles the get_my_info tool request.
 func (m *MCPServer) handleGetMyInfo(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// check WhatsApp connection

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -114,4 +114,18 @@ func (m *MCPServer) registerTools() {
 		),
 		m.handleGetMyInfo,
 	)
+
+	// 8. download_media: force download skipped/failed media
+	m.server.AddTool(
+		mcp.NewTool("download_media",
+			mcp.WithDescription("Force download media files that were previously skipped or failed. If message_id is provided, downloads that specific file. Otherwise lists and downloads all skipped/failed media."),
+			mcp.WithString("message_id",
+				mcp.Description("specific message ID to download media for (optional — if omitted, downloads all skipped/failed)"),
+			),
+			mcp.WithNumber("limit",
+				mcp.Description("maximum number of skipped files to download (default: 10, max: 50)"),
+			),
+		),
+		m.handleDownloadMedia,
+	)
 }


### PR DESCRIPTION
## Summary

Adds a new `download_media` MCP tool that force-downloads media files that were previously skipped or failed during auto-download.

### Use cases

- Media types not in the auto-download list (e.g., video was disabled but now you want specific videos)
- Transient download failures (network issues, WhatsApp server errors)
- Bulk retry of all failed/skipped media

### How it works

1. Queries `media_metadata` for entries with `download_status IN ('skipped', 'failed')`
2. Reconstructs synthetic proto messages from stored metadata (media_key, direct_path, SHA256 hashes)
3. Downloads via whatsmeow's `Download()` method
4. Verifies file integrity and updates status

### Parameters

- `message_id` (optional): Download a specific message's media
- `limit` (optional): Max files to process (default: 10, max: 50)

## Test plan

- [ ] Call with a specific `message_id` for a skipped file — should download and update status
- [ ] Call without parameters — should download all skipped/failed up to limit
- [ ] Call when no skipped files exist — should return clean message
- [ ] Verify downloaded files match expected SHA256 hashes