### PR TITLE
feat: add send_image and send_video MCP tools

### DIFF
--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -437,6 +437,65 @@ func (m *MCPServer) handleSendMessage(ctx context.Context, request mcp.CallToolR
 	return mcp.NewToolResultText(fmt.Sprintf("Message sent successfully to %s", chatJID)), nil
 }
 
+// handleSendImage handles the send_image tool request.
+func (m *MCPServer) handleSendImage(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	chatJID, err := request.RequireString("chat_jid")
+	if err != nil {
+		return mcp.NewToolResultError("chat_jid parameter is required"), nil
+	}
+
+	imageURL, err := request.RequireString("image_url")
+	if err != nil {
+		return mcp.NewToolResultError("image_url parameter is required"), nil
+	}
+
+	if !m.wa.IsLoggedIn() {
+		return mcp.NewToolResultError("WhatsApp is not connected"), nil
+	}
+
+	caption := request.GetString("caption", "")
+	replyTo := request.GetString("reply_to", "")
+
+	err = m.wa.SendImageMessage(ctx, chatJID, imageURL, caption, replyTo)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to send image: %v", err)), nil
+	}
+
+	mediaType := "Image"
+	if strings.Contains(strings.ToLower(imageURL), ".gif") {
+		mediaType = "GIF"
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("%s sent successfully to %s", mediaType, chatJID)), nil
+}
+
+// handleSendVideo handles the send_video tool request.
+func (m *MCPServer) handleSendVideo(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	chatJID, err := request.RequireString("chat_jid")
+	if err != nil {
+		return mcp.NewToolResultError("chat_jid parameter is required"), nil
+	}
+
+	video, err := request.RequireString("video")
+	if err != nil {
+		return mcp.NewToolResultError("video parameter is required"), nil
+	}
+
+	if !m.wa.IsLoggedIn() {
+		return mcp.NewToolResultError("WhatsApp is not connected"), nil
+	}
+
+	caption := request.GetString("caption", "")
+	replyTo := request.GetString("reply_to", "")
+
+	err = m.wa.SendVideoMessage(ctx, chatJID, video, caption, replyTo)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to send video: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Video sent successfully to %s", chatJID)), nil
+}
+
 // handleLoadMoreMessages handles the load_more_messages tool request.
 func (m *MCPServer) handleLoadMoreMessages(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// get required chat_jid

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -89,7 +89,51 @@ func (m *MCPServer) registerTools() {
 		m.handleSendMessage,
 	)
 
-	// 6. load more messages on-demand
+	// 6. send image/GIF
+	m.server.AddTool(
+		mcp.NewTool("send_image",
+			mcp.WithDescription("Send an image or GIF to a WhatsApp chat. Accepts a URL (http/https) or a local file path (absolute or ~/...). For GIFs, the image is sent as an animated GIF. Supports optional caption and reply."),
+			mcp.WithString("chat_jid",
+				mcp.Required(),
+				mcp.Description("recipient chat JID from find_chat or list_chats"),
+			),
+			mcp.WithString("image_url",
+				mcp.Required(),
+				mcp.Description("URL or local file path of the image or GIF to send"),
+			),
+			mcp.WithString("caption",
+				mcp.Description("optional caption text for the image"),
+			),
+			mcp.WithString("reply_to",
+				mcp.Description("message ID to reply to (the reply will appear linked/quoted in the chat)"),
+			),
+		),
+		m.handleSendImage,
+	)
+
+	// 7. send video
+	m.server.AddTool(
+		mcp.NewTool("send_video",
+			mcp.WithDescription("Send a video to a WhatsApp chat. Accepts a URL (http/https) or a local file path (absolute or ~/...). Supports optional caption and reply."),
+			mcp.WithString("chat_jid",
+				mcp.Required(),
+				mcp.Description("recipient chat JID from find_chat or list_chats"),
+			),
+			mcp.WithString("video",
+				mcp.Required(),
+				mcp.Description("URL or local file path of the video to send"),
+			),
+			mcp.WithString("caption",
+				mcp.Description("optional caption text for the video"),
+			),
+			mcp.WithString("reply_to",
+				mcp.Description("message ID to reply to (the reply will appear linked/quoted in the chat)"),
+			),
+		),
+		m.handleSendVideo,
+	)
+
+	// 8. load more messages on-demand
 	m.server.AddTool(
 		mcp.NewTool("load_more_messages",
 			mcp.WithDescription("Fetch additional message history from WhatsApp servers for a specific chat. Use when you need older messages not yet in the database."),
@@ -107,7 +151,7 @@ func (m *MCPServer) registerTools() {
 		m.handleLoadMoreMessages,
 	)
 
-	// 7. get my info
+	// 9. get my info
 	m.server.AddTool(
 		mcp.NewTool("get_my_info",
 			mcp.WithDescription("Get your own WhatsApp profile information including JID, display name, status/bio, and profile picture URL."),

--- a/whatsapp/client.go
+++ b/whatsapp/client.go
@@ -3,7 +3,12 @@ package whatsapp
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 	"whatsapp-mcp/paths"
@@ -215,6 +220,315 @@ func (c *Client) SendTextMessage(ctx context.Context, chatJID string, text strin
 		Timestamp:   resp.Timestamp,
 		IsFromMe:    true,
 		MessageType: "text",
+	})
+
+	return nil
+}
+
+// readMediaSource reads media data from a local file path or URL.
+// Returns the data bytes and MIME type.
+func (c *Client) readMediaSource(source string) ([]byte, string, error) {
+	const maxSize = 16 * 1024 * 1024
+
+	// Expand ~ to home directory
+	if strings.HasPrefix(source, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to expand home directory: %w", err)
+		}
+		source = home + source[1:]
+	}
+
+	if strings.HasPrefix(source, "/") {
+		// Local file
+		c.log.Infof("Reading local file: %s", source)
+		data, err := os.ReadFile(source)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read local file: %w", err)
+		}
+		if len(data) > maxSize {
+			return nil, "", fmt.Errorf("file too large (max 16MB)")
+		}
+		mimeType := http.DetectContentType(data)
+		return data, mimeType, nil
+	}
+
+	// URL
+	c.log.Infof("Downloading from URL: %s", source)
+	resp, err := http.Get(source)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("failed to download: HTTP %d", resp.StatusCode)
+	}
+
+	limitedReader := io.LimitReader(resp.Body, int64(maxSize)+1)
+	data, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read data: %w", err)
+	}
+	if len(data) > maxSize {
+		return nil, "", fmt.Errorf("file too large (max 16MB)")
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = http.DetectContentType(data)
+	}
+	return data, mimeType, nil
+}
+
+// convertGifToMp4 converts a GIF file to MP4 using ffmpeg.
+// Returns the MP4 data or an error if ffmpeg is not available or conversion fails.
+func convertGifToMp4(gifData []byte) ([]byte, error) {
+	tmpDir, err := os.MkdirTemp("", "wa-gif-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	gifPath := filepath.Join(tmpDir, "input.gif")
+	mp4Path := filepath.Join(tmpDir, "output.mp4")
+
+	if err := os.WriteFile(gifPath, gifData, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write temp gif: %w", err)
+	}
+
+	// Try common ffmpeg paths since LaunchAgents may have limited PATH
+	ffmpegPath := "ffmpeg"
+	for _, p := range []string{"/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"} {
+		if _, err := os.Stat(p); err == nil {
+			ffmpegPath = p
+			break
+		}
+	}
+
+	cmd := exec.Command(ffmpegPath, "-y", "-i", gifPath,
+		"-movflags", "faststart",
+		"-pix_fmt", "yuv420p",
+		"-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+		"-an", mp4Path)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("ffmpeg conversion failed: %w\n%s", err, string(output))
+	}
+
+	return os.ReadFile(mp4Path)
+}
+
+// SendImageMessage sends an image or GIF to a WhatsApp chat.
+// imageSource can be a URL (http/https) or a local file path (absolute or ~/...).
+// For GIF sources, it sends as a video with GifPlayback=true (WhatsApp requirement).
+func (c *Client) SendImageMessage(ctx context.Context, chatJID string, imageSource string, caption string, replyToID string) error {
+	c.log.Infof("SendImageMessage called: chatJID=%s, imageSource=%s, caption=%s", chatJID, imageSource, caption)
+
+	targetJID, err := types.ParseJID(chatJID)
+	if err != nil {
+		return fmt.Errorf("invalid chat JID: %w", err)
+	}
+
+	data, mimeType, err := c.readMediaSource(imageSource)
+	if err != nil {
+		return fmt.Errorf("failed to read image: %w", err)
+	}
+
+	isGif := strings.Contains(mimeType, "gif") || strings.HasSuffix(strings.ToLower(imageSource), ".gif")
+
+	// For GIFs: WhatsApp requires MP4 data with GifPlayback flag.
+	const maxMediaSize = 16 * 1024 * 1024
+	if isGif && strings.Contains(mimeType, "gif") && !strings.HasPrefix(imageSource, "/") {
+		mp4URL := strings.Replace(imageSource, "/giphy.gif", "/giphy.mp4", 1)
+		mp4URL = strings.Replace(mp4URL, "rid=giphy.gif", "rid=giphy.mp4", 1)
+		if mp4URL != imageSource {
+			c.log.Infof("GIF detected, fetching MP4 version: %s", mp4URL)
+			mp4Resp, err := http.Get(mp4URL)
+			if err == nil && mp4Resp.StatusCode == http.StatusOK {
+				mp4Data, err := io.ReadAll(io.LimitReader(mp4Resp.Body, maxMediaSize+1))
+				mp4Resp.Body.Close()
+				if err == nil && len(mp4Data) <= maxMediaSize && len(mp4Data) > 0 {
+					data = mp4Data
+					mimeType = "video/mp4"
+				}
+			} else if mp4Resp != nil {
+				mp4Resp.Body.Close()
+			}
+		}
+	}
+
+	// For local GIFs (or URL GIFs where MP4 fetch failed), convert with ffmpeg
+	if isGif && strings.Contains(mimeType, "gif") {
+		mp4Data, err := convertGifToMp4(data)
+		if err != nil {
+			c.log.Warnf("ffmpeg GIF conversion failed: %v (sending raw GIF)", err)
+		} else {
+			data = mp4Data
+			mimeType = "video/mp4"
+		}
+	}
+
+	var msg *waE2E.Message
+
+	if isGif {
+		uploaded, err := c.wa.Upload(ctx, data, whatsmeow.MediaVideo)
+		if err != nil {
+			return fmt.Errorf("failed to upload GIF: %w", err)
+		}
+
+		videoMsg := &waE2E.VideoMessage{
+			URL:           proto.String(uploaded.URL),
+			DirectPath:    proto.String(uploaded.DirectPath),
+			MediaKey:      uploaded.MediaKey,
+			FileEncSHA256: uploaded.FileEncSHA256,
+			FileSHA256:    uploaded.FileSHA256,
+			FileLength:    proto.Uint64(uint64(len(data))),
+			Mimetype:      proto.String(mimeType),
+			GifPlayback:   proto.Bool(true),
+		}
+		if caption != "" {
+			videoMsg.Caption = proto.String(caption)
+		}
+		msg = &waE2E.Message{VideoMessage: videoMsg}
+	} else {
+		uploaded, err := c.wa.Upload(ctx, data, whatsmeow.MediaImage)
+		if err != nil {
+			return fmt.Errorf("failed to upload image: %w", err)
+		}
+
+		imageMsg := &waE2E.ImageMessage{
+			URL:           proto.String(uploaded.URL),
+			DirectPath:    proto.String(uploaded.DirectPath),
+			MediaKey:      uploaded.MediaKey,
+			FileEncSHA256: uploaded.FileEncSHA256,
+			FileSHA256:    uploaded.FileSHA256,
+			FileLength:    proto.Uint64(uint64(len(data))),
+			Mimetype:      proto.String(mimeType),
+		}
+		if caption != "" {
+			imageMsg.Caption = proto.String(caption)
+		}
+		msg = &waE2E.Message{ImageMessage: imageMsg}
+	}
+
+	// Add reply context if specified
+	if replyToID != "" {
+		quotedMsg, err := c.store.GetMessageByID(replyToID)
+		if err != nil {
+			return fmt.Errorf("failed to look up quoted message: %w", err)
+		}
+		if quotedMsg == nil {
+			return fmt.Errorf("quoted message %s not found in database", replyToID)
+		}
+
+		contextInfo := &waE2E.ContextInfo{
+			StanzaID:      proto.String(replyToID),
+			Participant:   proto.String(quotedMsg.SenderJID),
+			QuotedMessage: &waE2E.Message{Conversation: proto.String(quotedMsg.Text)},
+		}
+
+		if isGif {
+			msg.VideoMessage.ContextInfo = contextInfo
+		} else {
+			msg.ImageMessage.ContextInfo = contextInfo
+		}
+	}
+
+	sendResp, err := c.wa.SendMessage(ctx, targetJID, msg)
+	if err != nil {
+		return fmt.Errorf("failed to send image: %w", err)
+	}
+
+	c.log.Infof("Image sent successfully! ID=%s", sendResp.ID)
+	msgType := "image"
+	if isGif {
+		msgType = "gif"
+	}
+	text := caption
+	if text == "" {
+		text = "[" + msgType + "]"
+	}
+
+	c.store.SaveMessage(storage.Message{
+		ID:          sendResp.ID,
+		ChatJID:     chatJID,
+		SenderJID:   sendResp.Sender.String(),
+		Text:        text,
+		Timestamp:   sendResp.Timestamp,
+		IsFromMe:    true,
+		MessageType: msgType,
+	})
+
+	return nil
+}
+
+// SendVideoMessage sends a video to a WhatsApp chat.
+// videoSource can be a URL (http/https) or a local file path (absolute or ~/...).
+func (c *Client) SendVideoMessage(ctx context.Context, chatJID string, videoSource string, caption string, replyToID string) error {
+	targetJID, err := types.ParseJID(chatJID)
+	if err != nil {
+		return fmt.Errorf("invalid chat JID: %w", err)
+	}
+
+	data, mimeType, err := c.readMediaSource(videoSource)
+	if err != nil {
+		return fmt.Errorf("failed to read video: %w", err)
+	}
+
+	uploaded, err := c.wa.Upload(ctx, data, whatsmeow.MediaVideo)
+	if err != nil {
+		return fmt.Errorf("failed to upload video: %w", err)
+	}
+
+	videoMsg := &waE2E.VideoMessage{
+		URL:           proto.String(uploaded.URL),
+		DirectPath:    proto.String(uploaded.DirectPath),
+		MediaKey:      uploaded.MediaKey,
+		FileEncSHA256: uploaded.FileEncSHA256,
+		FileSHA256:    uploaded.FileSHA256,
+		FileLength:    proto.Uint64(uint64(len(data))),
+		Mimetype:      proto.String(mimeType),
+	}
+	if caption != "" {
+		videoMsg.Caption = proto.String(caption)
+	}
+
+	msg := &waE2E.Message{VideoMessage: videoMsg}
+
+	// Add reply context if specified
+	if replyToID != "" {
+		quotedMsg, err := c.store.GetMessageByID(replyToID)
+		if err != nil {
+			return fmt.Errorf("failed to look up quoted message: %w", err)
+		}
+		if quotedMsg == nil {
+			return fmt.Errorf("quoted message %s not found in database", replyToID)
+		}
+		msg.VideoMessage.ContextInfo = &waE2E.ContextInfo{
+			StanzaID:      proto.String(replyToID),
+			Participant:   proto.String(quotedMsg.SenderJID),
+			QuotedMessage: &waE2E.Message{Conversation: proto.String(quotedMsg.Text)},
+		}
+	}
+
+	sendResp, err := c.wa.SendMessage(ctx, targetJID, msg)
+	if err != nil {
+		return fmt.Errorf("failed to send video: %w", err)
+	}
+
+	text := caption
+	if text == "" {
+		text = "[video]"
+	}
+
+	c.store.SaveMessage(storage.Message{
+		ID:          sendResp.ID,
+		ChatJID:     chatJID,
+		SenderJID:   sendResp.Sender.String(),
+		Text:        text,
+		Timestamp:   sendResp.Timestamp,
+		IsFromMe:    true,
+		MessageType: "video",
 	})
 
 	return nil


### PR DESCRIPTION
## Summary

Adds two new MCP tools for sending media messages: `send_image` and `send_video`.

> **Note**: This is an alternative implementation to #23 with additional features. Happy to coordinate/merge approaches.

### Features

- **Flexible media sources**: Accept both URLs (http/https) and local file paths (absolute or ~/...)
- **GIF support**: Automatic GIF→MP4 conversion since WhatsApp requires video format for animated content
  - Smart Giphy URL handling: fetches .mp4 version directly when available
  - ffmpeg fallback for local GIF files or non-Giphy URLs
- **Caption support**: Optional caption text for both images and videos
- **Reply-to support**: Send media as a reply to a specific message
- **Size validation**: 16MB limit with clear error messages

### Tools

#### send_image
| Parameter | Required | Description |
|-----------|----------|-------------|
| chat_jid | Yes | Recipient chat JID |
| image_url | Yes | URL or local file path |
| caption | No | Caption text |
| reply_to | No | Message ID to reply to |

#### send_video
| Parameter | Required | Description |
|-----------|----------|-------------|
| chat_jid | Yes | Recipient chat JID |
| video | Yes | URL or local file path |
| caption | No | Caption text |
| reply_to | No | Message ID to reply to |

## Test plan

- [ ] Send image from URL — should upload and deliver
- [ ] Send image from local path — should read and deliver
- [ ] Send GIF from Giphy URL — should convert to MP4 and deliver as animated
- [ ] Send local GIF file — should convert via ffmpeg and deliver
- [ ] Send video from URL — should upload and deliver
- [ ] Send with caption — caption should appear in WhatsApp
- [ ] Send as reply — should appear as quoted reply
- [ ] Send file >16MB — should return clear error