### PR TITLE
feat(auth): accept Authorization: Bearer header on /mcp endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Existing clients using `/mcp/{key}` continue to work unchanged.
   "mcpServers": {
     "whatsapp": {
       "url": "http://localhost:8080/mcp/your-secret-api-key",
-      "transport": "http"
+      "type": "http"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -203,8 +203,11 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 {
   "mcpServers": {
     "whatsapp": {
-      "url": "http://localhost:8080/mcp/your-secret-api-key",
-      "transport": "http"
+      "type": "http",
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer your-secret-api-key"
+      }
     }
   }
 }
@@ -212,11 +215,44 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 ### Connect to Other MCP Clients
 
-The server exposes an HTTP+SSE endpoint compatible with any MCP client:
+The server exposes a Streamable HTTP endpoint compatible with any MCP client:
 
-- **URL:** `http://localhost:8080/mcp/{API_KEY}`
+- **URL:** `http://localhost:8080/mcp`
 - **Transport:** Streamable HTTP
-- **Authentication:** API key in URL path
+- **Authentication:** Two methods supported (Bearer header preferred)
+
+**Option A — Authorization header (recommended):**
+
+Keeps the key out of URLs, proxy logs, and shell history.
+
+```json
+{
+  "mcpServers": {
+    "whatsapp": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer your-secret-api-key"
+      }
+    }
+  }
+}
+```
+
+**Option B — Key in URL path (backward compatible):**
+
+Existing clients using `/mcp/{key}` continue to work unchanged.
+
+```json
+{
+  "mcpServers": {
+    "whatsapp": {
+      "url": "http://localhost:8080/mcp/your-secret-api-key",
+      "transport": "http"
+    }
+  }
+}
+```
 
 ## 🎨 Usage Examples
 

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"log"
 	"net/http"
@@ -193,20 +194,32 @@ func main() {
 		server.WithEndpointPath("/mcp"),
 	)
 
-	// MCP endpoint with API key in path
+	// MCP endpoint. Authenticates via either an "Authorization: Bearer <key>"
+	// header (preferred — keeps the key out of URLs/logs) or the API key as the
+	// first path segment (/mcp/{apiKey}) for backward compatibility.
 	mux.HandleFunc("/mcp/", func(w http.ResponseWriter, r *http.Request) {
-		// Extract API key from URL path: /mcp/{apiKey}
 		path := strings.TrimPrefix(r.URL.Path, "/mcp/")
-		providedKey := strings.Split(path, "/")[0] // Get first segment after /mcp/
+		providedKey := strings.Split(path, "/")[0] // first segment after /mcp/
 
-		if providedKey != apiKey {
+		authHeader := r.Header.Get("Authorization")
+		headerOK := subtle.ConstantTimeCompare([]byte(authHeader), []byte("Bearer "+apiKey)) == 1
+		pathOK := subtle.ConstantTimeCompare([]byte(providedKey), []byte(apiKey)) == 1
+
+		// remainingPath is the MCP path after the auth segment is stripped.
+		var remainingPath string
+		switch {
+		case headerOK:
+			// Key is in the header; the whole path after /mcp/ is the MCP path.
+			remainingPath = path
+		case pathOK:
+			// Key is in the path; strip it.
+			remainingPath = strings.TrimPrefix(path, providedKey)
+		default:
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte("Unauthorized: Invalid API key"))
 			return
 		}
 
-		// Create a new request with the remaining path
-		remainingPath := strings.TrimPrefix(path, providedKey)
 		if !strings.HasPrefix(remainingPath, "/") {
 			remainingPath = "/" + remainingPath
 		}


### PR DESCRIPTION
## Problem

The `/mcp/{API_KEY}` pattern embeds the secret key in the URL, which means it appears in:
- Reverse proxy access logs
- Browser history
- Any config file that stores the full connection URL (e.g. Claude Desktop `claude_desktop_config.json`)

## Solution

Accept `Authorization: Bearer <key>` as an alternative authentication method. The path-segment form (`/mcp/{key}`) remains fully supported for backward compatibility — existing clients need no changes.

Both auth paths use `crypto/subtle.ConstantTimeCompare` to prevent timing attacks.

## Changes

- `main.go`: check `Authorization: Bearer <key>` header first; fall back to key-in-path
- `README.md`: update MCP Integration section to show both options; recommend Bearer header for new setups; update Claude Desktop config example

## Backward compatibility

Fully backward compatible. Existing `url: "http://host/mcp/{key}"` configs continue to work.