### PR TITLE
feat(webhook): forward CTWA ExternalAdReply referral metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,98 @@ AI assistants can access these guides through the MCP Resources API.
 
 See `.env.example` and be happy!
 
+## 🔔 Webhook Events
+
+When `WEBHOOK_URL` is set, the server POSTs a JSON payload to that URL for every incoming and outgoing message.
+
+### Payload Structure
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "event_type": "message.received",
+  "timestamp": "2026-06-14T10:00:00Z",
+  "data": {
+    "message_id": "3EB0...",
+    "chat_jid": "6281234567890@s.whatsapp.net",
+    "sender_jid": "6281234567890@s.whatsapp.net",
+    "text": "Hello!",
+    "timestamp": "2026-06-14T10:00:00Z",
+    "is_from_me": false,
+    "message_type": "text",
+    "chat_name": "John Doe",
+    "sender_push_name": "John",
+    "sender_contact_name": "John Doe",
+    "is_group": false,
+    "media_metadata": null,
+    "referral": null
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string (UUID) | Unique event identifier |
+| `event_type` | string | `message.received` or `message.sent` |
+| `timestamp` | string (RFC3339) | When the event was generated |
+| `data.message_id` | string | WhatsApp message ID |
+| `data.chat_jid` | string | JID of the chat (DM or group) |
+| `data.sender_jid` | string | JID of the sender |
+| `data.text` | string | Message text content |
+| `data.timestamp` | string (RFC3339) | When the message was sent |
+| `data.is_from_me` | bool | `true` if sent from your account |
+| `data.message_type` | string | `text`, `image`, `video`, `audio`, `document`, `sticker`, `ptt`, `gif` |
+| `data.chat_name` | string | Display name of the chat (omitted if empty) |
+| `data.sender_push_name` | string | WhatsApp display name of the sender (omitted if empty) |
+| `data.sender_contact_name` | string | Local contact name for the sender (omitted if empty) |
+| `data.is_group` | bool | `true` if the message is in a group chat |
+| `data.media_metadata` | object \| null | Present when message has a media attachment (see below) |
+| `data.referral` | object \| null | Present when message originated from a Meta Click-to-WhatsApp ad (see below) |
+
+### Media Metadata
+
+Present when `message_type` is `image`, `video`, `audio`, `document`, `sticker`, `ptt`, or `gif`.
+
+```json
+"media_metadata": {
+  "message_id": "3EB0...",
+  "file_name": "photo.jpg",
+  "file_size": 204800,
+  "mime_type": "image/jpeg",
+  "has_media": true
+}
+```
+
+### Referral (Click-to-WhatsApp Ads)
+
+When a user taps a Meta ad with a "Message on WhatsApp" button, their first message carries ad attribution metadata (`ExternalAdReply` in the WhatsApp protocol). The server extracts this and populates `referral`:
+
+```json
+"referral": {
+  "ctwa_clid": "ARAkLkA8...",
+  "source_id": "120208468219880053",
+  "source_type": "AD",
+  "source_url": "https://fb.com/ads/...",
+  "headline": "Order Now"
+}
+```
+
+| Field | Description |
+|---|---|
+| `ctwa_clid` | Meta's click ID — use this for offline conversion attribution via Meta Conversions API |
+| `source_id` | The ad ID that originated the conversation |
+| `source_type` | Ad placement type (e.g. `AD`) |
+| `source_url` | Destination URL of the ad |
+| `headline` | Ad creative headline text |
+
+`referral` is `null` for all non-ad messages. It is supported on text, image, and video messages (the message types where WhatsApp carries `ExternalAdReply`).
+
+### Delivery & Retries
+
+Failed deliveries are retried up to `WEBHOOK_MAX_RETRIES` times with exponential backoff. Delivery attempts are logged in the database and visible via the webhook management API (`GET /webhooks/deliveries`).
+
 ## 🤝 Contributing
 
 This is a personal project I maintain for daily use. Contributions are welcome!

--- a/storage/messages.go
+++ b/storage/messages.go
@@ -17,6 +17,16 @@ type Message struct {
 	MessageType string
 }
 
+// ReferralInfo holds Click-to-WhatsApp (CTWA) ad referral metadata extracted from
+// ExternalAdReply ContextInfo. It is not persisted to the database.
+type ReferralInfo struct {
+	CtwaClid   string `json:"ctwa_clid,omitempty"`
+	SourceID   string `json:"source_id,omitempty"`
+	SourceType string `json:"source_type,omitempty"`
+	SourceURL  string `json:"source_url,omitempty"`
+	Headline   string `json:"headline,omitempty"`
+}
+
 // MessageWithNames represents a message with sender and chat names from the database view.
 type MessageWithNames struct {
 	Message
@@ -24,6 +34,7 @@ type MessageWithNames struct {
 	SenderContactName string         // Current saved contact name (from chats table)
 	ChatName          string         // Current chat name (for display)
 	MediaMetadata     *MediaMetadata // Associated media metadata (null if no media)
+	Referral          *ReferralInfo  // CTWA ad referral metadata (null if no ad referral)
 }
 
 // MessageStore handles message operations on the database.

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -20,6 +20,15 @@ type WebhookPayload struct {
 	Data      MessageEventData `json:"data"`
 }
 
+// ReferralInfo holds Click-to-WhatsApp (CTWA) ad referral metadata.
+type ReferralInfo struct {
+	CtwaClid   string `json:"ctwa_clid,omitempty"`
+	SourceID   string `json:"source_id,omitempty"`
+	SourceType string `json:"source_type,omitempty"`
+	SourceURL  string `json:"source_url,omitempty"`
+	Headline   string `json:"headline,omitempty"`
+}
+
 // MessageEventData contains the message event details.
 type MessageEventData struct {
 	MessageID         string          `json:"message_id"`
@@ -34,6 +43,7 @@ type MessageEventData struct {
 	SenderContactName string          `json:"sender_contact_name,omitempty"`
 	IsGroup           bool            `json:"is_group"`
 	MediaMetadata     *MediaReference `json:"media_metadata,omitempty"`
+	Referral          *ReferralInfo   `json:"referral,omitempty"`
 }
 
 // MediaReference contains metadata about media attachments.
@@ -189,6 +199,17 @@ func (m *WebhookManager) buildMessagePayload(msg storage.MessageWithNames) Webho
 			FileSize:  msg.MediaMetadata.FileSize,
 			MimeType:  msg.MediaMetadata.MimeType,
 			HasMedia:  msg.MediaMetadata.FilePath != "",
+		}
+	}
+
+	// Forward CTWA ad referral if present
+	if msg.Referral != nil {
+		data.Referral = &ReferralInfo{
+			CtwaClid:   msg.Referral.CtwaClid,
+			SourceID:   msg.Referral.SourceID,
+			SourceType: msg.Referral.SourceType,
+			SourceURL:  msg.Referral.SourceURL,
+			Headline:   msg.Referral.Headline,
 		}
 	}
 

--- a/whatsapp/handlers.go
+++ b/whatsapp/handlers.go
@@ -477,6 +477,7 @@ func (c *Client) handleMessage(evt *events.Message) {
 			SenderPushName:    senderPushName,
 			SenderContactName: senderContactName,
 			MediaMetadata:     mediaMetadata,
+			Referral:          extractReferral(evt.Message),
 		}
 
 		// Emit webhook event (already non-blocking via worker queue)
@@ -817,6 +818,60 @@ func (c *Client) handleHistorySync(evt *events.HistorySync) {
 			}
 		}
 		c.historySyncMux.Unlock()
+	}
+}
+
+// extractReferral extracts Click-to-WhatsApp (CTWA) ad referral metadata from a message.
+// CTWA clicks arrive as ExtendedTextMessage, ImageMessage, or VideoMessage with
+// ExternalAdReply in ContextInfo. Returns nil when no ad referral is present.
+func extractReferral(msg *waE2E.Message) *storage.ReferralInfo {
+	if msg == nil {
+		return nil
+	}
+
+	var adReply interface {
+		GetCtwaClid() string
+		GetSourceID() string
+		GetSourceType() string
+		GetSourceURL() string
+		GetTitle() string
+	}
+
+	if ext := msg.GetExtendedTextMessage(); ext != nil {
+		if ci := ext.GetContextInfo(); ci != nil {
+			adReply = ci.GetExternalAdReply()
+		}
+	} else if img := msg.GetImageMessage(); img != nil {
+		if ci := img.GetContextInfo(); ci != nil {
+			adReply = ci.GetExternalAdReply()
+		}
+	} else if vid := msg.GetVideoMessage(); vid != nil {
+		if ci := vid.GetContextInfo(); ci != nil {
+			adReply = ci.GetExternalAdReply()
+		}
+	}
+
+	if adReply == nil {
+		return nil
+	}
+
+	clid := adReply.GetCtwaClid()
+	sid := adReply.GetSourceID()
+	stype := adReply.GetSourceType()
+	surl := adReply.GetSourceURL()
+	headline := adReply.GetTitle()
+
+	// Only return referral when at least ctwa_clid or source_id is present
+	if clid == "" && sid == "" {
+		return nil
+	}
+
+	return &storage.ReferralInfo{
+		CtwaClid:   clid,
+		SourceID:   sid,
+		SourceType: stype,
+		SourceURL:  surl,
+		Headline:   headline,
 	}
 }
 


### PR DESCRIPTION
## What

When a user taps a Meta "Click-to-WhatsApp" (CTWA) ad, their opening message contains `ExternalAdReply` metadata in the WhatsApp protocol — the ad ID, a click ID for conversion attribution, the ad headline, etc. This PR extracts that metadata and includes it in the webhook event payload.

## Why

Without this, consumers of the webhook (n8n, custom integrations, CRMs) have no way to know which ad led to a conversation. With it, they can:
- Forward the `ctwa_clid` to Meta Conversions API for offline conversion attribution
- Route leads differently based on which campaign they came from
- Track ROAS per ad at the conversation level

## Changes

**`whatsapp/handlers.go`** — extract `ExternalAdReply` from `ContextInfo` for `ExtendedTextMessage`, `ImageMessage`, and `VideoMessage`; populate a `ReferralInfo` struct.

**`webhook/webhook.go`** — add `ReferralInfo` struct with fields `ctwa_clid`, `source_id`, `source_type`, `source_url`, `headline`; add `Referral *ReferralInfo` field (omitempty) to `MessageEventData`.

**`storage/messages.go`** — thread `ReferralInfo` through to the webhook payload.

**`README.md`** — add "Webhook Events" section documenting the full payload schema, all fields, and the `referral` object.

## Backward compatibility

`referral` uses `omitempty` — it is absent from the JSON for all normal messages. Existing webhook consumers are unaffected.